### PR TITLE
fix the 'last updated' plugin when run on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       dirs: ${{ steps.load.outputs.dirs }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - id: load
         run: |
@@ -33,7 +33,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Check if Docker rebuild is necessary
         id: changed
         uses: dorny/paths-filter@v3
@@ -75,7 +75,7 @@ jobs:
     container:
       image: ghcr.io/${{ github.repository }}/arm-gnu:13.3
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Create python venv
         run: |
@@ -105,7 +105,7 @@ jobs:
 
     steps:
       - name: Checkout repo and submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: 'recursive'
 

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -26,7 +26,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           sparse-checkout: docs
@@ -37,7 +37,7 @@ jobs:
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.x
 

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -27,6 +27,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          sparse-checkout: docs
 
       - name: Configure git credentials # for gh-deploy
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -49,6 +49,14 @@ jobs:
         if: github.event_name != 'push' || github.ref != 'refs/heads/main'
         run: mkdocs build --strict
 
+      - name: Upload site artifact
+        if: github.event_name != 'push' || github.ref != 'refs/heads/main'
+        uses: actions/upload-artifact@v6
+        with:
+          name: site
+          path: site/
+          retention-days: 7
+
       # Pushes to main: actually deploy
       - name: MkDocs deploy to GitHub Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
- 'last updated' plugin on docs requires larger commit history, so added the snippet below which will get a pull a larger commit history for docs files. I don't think it will cause a large performance hit in the CI, but if it does, we can just scrap this plugin
```
      - uses: actions/checkout@v6
        with:
          fetch-depth: 0
          sparse-checkout: docs
```
- uprev actions/checkout and actions/setup-python to versions which use node 24 instead of node 20 since node 20 is reaching eol on the github servers in a couple months
- add CI build artifacts to view the site that CI builds (https://github.com/umrover/mrover-esw/actions/runs/23384698237?pr=59)