### PR TITLE
venv cmake updates for offline support

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -15,31 +15,32 @@ else()
     set(VENV_PIP ${VENV_DIR}/bin/pip)
 endif()
 
-add_custom_command(
-    OUTPUT ${VENV_DIR}/pyvenv.cfg
-    COMMAND ${Python3_EXECUTABLE} -m venv ${VENV_DIR}
-    COMMENT "creating venv"
-    VERBATIM
-)
-
-add_custom_target(python_venv DEPENDS ${VENV_DIR}/pyvenv.cfg)
-
 set(PYPROJECT_TOML ${TOOLS_DIR}/pyproject.toml)
+set(SETUP_SCRIPT ${TOOLS_DIR}/setup_venv.py)
 
-add_custom_command(
-    OUTPUT ${VENV_DIR}/package.timestamp
-    DEPENDS python_venv ${PYPROJECT_TOML}
-    WORKING_DIRECTORY ${TOOLS_DIR}
-    COMMAND ${VENV_PIP} install --upgrade pip setuptools wheel
-    COMMAND ${VENV_PIP} install --editable ".[dev]"
-    COMMAND ${CMAKE_COMMAND} -E touch ${VENV_DIR}/package.timestamp
-    COMMENT "installing esw python tools"
-    VERBATIM
+# auto reconfigure on pyproject change
+set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS ${PYPROJECT_TOML})
+
+message(STATUS "executing venv setup")
+execute_process(
+    COMMAND ${Python3_EXECUTABLE} ${SETUP_SCRIPT} ${VENV_DIR} ${PYPROJECT_TOML} ${VENV_PIP}
+    RESULT_VARIABLE VENV_RESULT
+    OUTPUT_VARIABLE VENV_OUTPUT
+    ERROR_VARIABLE VENV_ERROR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
-add_custom_target(python_package DEPENDS ${VENV_DIR}/package.timestamp)
+if(NOT VENV_RESULT EQUAL 0)
+    message(FATAL_ERROR "python environment setup failed\n${VENV_OUTPUT}\n${VENV_ERROR}")
+elseif(VENV_OUTPUT MATCHES "^WARNING:")
+    string(REGEX REPLACE "^WARNING:[ \t]*" "" CLEAN_WARNING "${VENV_OUTPUT}")
+    message(WARNING "${CLEAN_WARNING}")
+elseif(VENV_OUTPUT MATCHES "^STATUS:")
+    string(REGEX REPLACE "^STATUS:[ \t]*" "" CLEAN_STATUS "${VENV_OUTPUT}")
+    message(STATUS "${CLEAN_STATUS}")
+endif()
 
-add_custom_target(python_env_ready DEPENDS python_package)
+add_custom_target(python_env_ready)
 
 function(run_python_tool TARGET_NAME SCRIPT)
     add_custom_target(

--- a/tools/setup_venv.py
+++ b/tools/setup_venv.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+import sys
+import os
+import urllib.request
+import subprocess
+import pathlib
+
+venv_dir = sys.argv[1]
+pyproject_toml = sys.argv[2]
+venv_pip = sys.argv[3]
+
+pyvenv_cfg = os.path.join(venv_dir, 'pyvenv.cfg')
+venv_exists = os.path.exists(pyvenv_cfg)
+timestamp_file = os.path.join(venv_dir, 'package.timestamp')
+
+if venv_exists and os.path.exists(timestamp_file):
+    if os.path.getmtime(timestamp_file) >= os.path.getmtime(pyproject_toml):
+        print("STATUS: venv is already up-to-date (cached)")
+        sys.exit(0)
+
+has_internet = False
+try:
+    urllib.request.urlopen('https://pypi.org', timeout=3)
+    has_internet = True
+except Exception:
+    pass
+
+if has_internet:
+    try:
+        if not venv_exists:
+            subprocess.run([sys.executable, '-m', 'venv', venv_dir], check=True, capture_output=True)
+
+        subprocess.run([venv_pip, 'install', '--upgrade', 'pip', 'setuptools', 'wheel'], check=True, capture_output=True)
+        subprocess.run([venv_pip, 'install', '--editable', '.[dev]'], cwd=os.path.dirname(pyproject_toml), check=True, capture_output=True)
+
+        pathlib.Path(timestamp_file).touch()
+
+        print("STATUS: env successfully synced with internet")
+        sys.exit(0)
+    except subprocess.CalledProcessError as e:
+        print(f"FATAL: failed to install packages\n{e.stderr.decode('utf-8')}")
+        sys.exit(1)
+else:
+    if not venv_exists:
+        print(f"FATAL: venv does not exist at {venv_dir} and cannot be created offline")
+        sys.exit(1)
+
+    try:
+        result = subprocess.run([venv_pip, 'list', '--outdated'], capture_output=True, text=True, timeout=4)
+        pathlib.Path(timestamp_file).touch()
+
+        if result.returncode == 0 and result.stdout.strip():
+            print(f"WARNING: offline mode, packages out of date:\n{result.stdout}")
+        else:
+            print("STATUS: offline mode, env matches local state")
+        sys.exit(0)
+    except Exception:
+        pathlib.Path(timestamp_file).touch()
+        print("WARNING: entirely offline, skipping version comparison checks")
+        sys.exit(0)

--- a/tools/setup_venv.py
+++ b/tools/setup_venv.py
@@ -9,9 +9,9 @@ venv_dir = sys.argv[1]
 pyproject_toml = sys.argv[2]
 venv_pip = sys.argv[3]
 
-pyvenv_cfg = os.path.join(venv_dir, 'pyvenv.cfg')
+pyvenv_cfg = os.path.join(venv_dir, "pyvenv.cfg")
 venv_exists = os.path.exists(pyvenv_cfg)
-timestamp_file = os.path.join(venv_dir, 'package.timestamp')
+timestamp_file = os.path.join(venv_dir, "package.timestamp")
 
 if venv_exists and os.path.exists(timestamp_file):
     if os.path.getmtime(timestamp_file) >= os.path.getmtime(pyproject_toml):
@@ -20,7 +20,7 @@ if venv_exists and os.path.exists(timestamp_file):
 
 has_internet = False
 try:
-    urllib.request.urlopen('https://pypi.org', timeout=3)
+    urllib.request.urlopen("https://pypi.org", timeout=3)
     has_internet = True
 except Exception:
     pass
@@ -28,10 +28,17 @@ except Exception:
 if has_internet:
     try:
         if not venv_exists:
-            subprocess.run([sys.executable, '-m', 'venv', venv_dir], check=True, capture_output=True)
+            subprocess.run([sys.executable, "-m", "venv", venv_dir], check=True, capture_output=True)
 
-        subprocess.run([venv_pip, 'install', '--upgrade', 'pip', 'setuptools', 'wheel'], check=True, capture_output=True)
-        subprocess.run([venv_pip, 'install', '--editable', '.[dev]'], cwd=os.path.dirname(pyproject_toml), check=True, capture_output=True)
+        subprocess.run(
+            [venv_pip, "install", "--upgrade", "pip", "setuptools", "wheel"], check=True, capture_output=True
+        )
+        subprocess.run(
+            [venv_pip, "install", "--editable", ".[dev]"],
+            cwd=os.path.dirname(pyproject_toml),
+            check=True,
+            capture_output=True,
+        )
 
         pathlib.Path(timestamp_file).touch()
 
@@ -46,7 +53,7 @@ else:
         sys.exit(1)
 
     try:
-        result = subprocess.run([venv_pip, 'list', '--outdated'], capture_output=True, text=True, timeout=4)
+        result = subprocess.run([venv_pip, "list", "--outdated"], capture_output=True, text=True, timeout=4)
         pathlib.Path(timestamp_file).touch()
 
         if result.returncode == 0 and result.stdout.strip():


### PR DESCRIPTION
should speed up ROS2 build and make fw builds more stable

errors if no venv and offline, should allow one build to be good for competition environment
warns if packages out of sync, but allows it to proceed (might create errors downstream)